### PR TITLE
Add solution for Exercise Ownership References

### DIFF
--- a/exercise/e_ownership_references/src/lib.rs
+++ b/exercise/e_ownership_references/src/lib.rs
@@ -1,0 +1,22 @@
+pub fn inspect(arg: &String) {
+    let plu_or_sin = if arg.ends_with('s') {
+        "plural"
+    } else {
+        "singular"
+    };
+    println!("'{}' is {}", arg, plu_or_sin);
+}
+
+pub fn change(arg: &mut String) {
+    if !arg.ends_with('s') {
+        arg.push('s');
+    }
+}
+
+pub fn eat(arg: String) -> bool {
+    arg.starts_with('b') && arg.contains('a')
+}
+
+pub fn bedazzle(material: &mut String) {
+    *material = "sparkly".to_string();
+}

--- a/exercise/e_ownership_references/src/main.rs
+++ b/exercise/e_ownership_references/src/main.rs
@@ -1,5 +1,4 @@
-// Silence some warnings so they don't distract from the exercise.
-#![allow(unused_mut, unused_variables)]
+use e_ownership_references::{change, eat, inspect, bedazzle};
 
 fn main() {
     // This fancy stuff either gets the first argument as a String, or prints
@@ -9,30 +8,16 @@ fn main() {
         std::process::exit(-1);
     });
 
-    // 1. Write a function `inspect` that takes a reference to a String, returns nothing, but
-    // prints whether the contents of the String is plural or singular. Then uncomment and run this
-    // code with `cargo run apple` and `cargo run apples'.  Hint: use `.ends_with("s")` on the
-    // String reference
-    //
-    //inspect(&arg);
+    inspect(&arg);
 
-    // 2. Write a function `change` that takes a *mutable* reference to a String and adds an "s" to
-    // the String if it doesn't already end with "s". Then uncomment and run the code below with
-    // `cargo run apple`.  Hint: use `.push_str("s")` on the mutable String reference to add an "s".
-    //
-    //change(&mut arg);
-    //println!("I have many {}", arg);
+    change(&mut arg);
+    println!("I have many {}", arg);
 
-    // 3. Write a function `eat` that accepts ownership of (consumes) a String and returns a bool
-    // indicating whether or not the String both starts with a "b" AND contains an "a".
-    // Hint 1: use `.starts_with("b")` and `.contains("a")`
-    // Hint 2: `&&` is the boolean "AND" operator
-    //
-    //if eat(arg) {
-    //    println!("Might be bananas");
-    //} else {
-    //    println!("Not bananas");
-    //}
+    if eat(arg) {
+        println!("Might be bananas");
+    } else {
+        println!("Not bananas");
+    }
 
     // Try running this program with "boat", "banana", and "grapes" as the arguments :-)
 
@@ -43,8 +28,8 @@ fn main() {
     // Hint: You will need to dereference the mutable reference in order to assign it a
     // new value.
     //
-    // let mut material = "mud".to_string();
-    // println!("This material is just `{}`.", material);
-    // bedazzle(&mut material);
-    // println!("Wow! Now the material is `{}`!", material);
+    let mut material = "mud".to_string();
+    println!("This material is just `{}`.", material);
+    bedazzle(&mut material);
+    println!("Wow! Now the material is `{}`!", material);
 }


### PR DESCRIPTION
## Description

This PR adds solution for Exercise Ownership References, includes:
- Add `inspect` function to check plural or singular arg
- Add `change` function to transform to plural if not
- Add `eat` function to check if it may be 'banana'
- Add `bedazzle` function to change variable value using dereference